### PR TITLE
Limit rubyzip version, as advised by rubyzip readme

### DIFF
--- a/build.desc
+++ b/build.desc
@@ -15,7 +15,7 @@ rubygem(
   ],
   gemdeps = [
     { "json_pure"    : ">= 0"     },
-    { "rubyzip"      : ">= 0"     },
+    { "rubyzip"      : "< 1.0.0"  },
     { "childprocess" : ">= 0.1.9" },
     { "ffi"          : ">= 1.0.7" }
   ],


### PR DESCRIPTION
Attempt to fix #3 with minimal change, the new dependency declaration is a true reflection of reality.

This should allow end users to continue using selenium-webdriver Ruby gem with minimal disruption. A better long-term response to changes in rubyzip may require a little more thought and planning.
